### PR TITLE
feat: no need to ref/unref with new PLAYA-PDF (rhymes, and also fixes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ This is generally faster than `pdfminer.six`.  You can often make it
 even faster on large documents by running in parallel with the
 `max_workers` argument, which is the same as the one you will find in
 `concurrent.futures.ProcessPoolExecutor`.  If you pass `None` it will
-use all your CPUs, but due to some unfortunate overhead (which will be
-fixed soon) this isn't so great, so 2-4 workers is best:
+use all your CPUs, but due to some unavoidable overhead, it usually
+doesn't help to use more than 2-4:
 
 ```
 for page in extract(path, laparams, max_workers=2):
@@ -116,9 +116,8 @@ from paves.bears import SCHEMA
 df = polars.DataFrame(extract(path), schema=SCHEMA)
 ```
 
-As above, you can use multiple CPUs with `max_workers`, though this
-will scale considerably better since the objects are (mostly) easily
-serializable.
+As above, you can use multiple CPUs with `max_workers`, and this will
+scale considerably better than `paves.miner`.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "playa-pdf >= 0.2.7, < 0.3"  # not considered harmful as we depend on internals
+  "playa-pdf >= 0.2.8, < 0.3"  # not considered harmful as we depend on internals
 ]
 
 [project.urls]

--- a/src/paves/bears.py
+++ b/src/paves/bears.py
@@ -27,7 +27,6 @@ from playa.utils import (
 )
 import playa
 from playa import DeviceSpace, LayoutDict, fieldnames as FIELDNAMES, schema as SCHEMA  # noqa: F401
-from paves.miner import unref_colorspace, ref_colorspace
 
 LOG = logging.getLogger(__name__)
 
@@ -181,9 +180,7 @@ def _(obj: ImageObject) -> Iterator[LayoutDict]:
         srcsize=obj.srcsize,
         imagemask=obj.imagemask,
         bits=obj.bits,
-        image_colorspace=None
-        if obj.colorspace is None
-        else unref_colorspace(obj.colorspace),
+        image_colorspace=obj.colorspace,
         stream=stream_id,
         page_index=0,
         page_label="0",
@@ -272,8 +269,4 @@ def extract(
         mp_context=mp_context,
     ) as pdf:
         for page in pdf.pages.map(extract_page):
-            for dic in page:
-                cs = dic.get("image_colorspace")
-                if cs is not None:
-                    dic["image_colorspace"] = ref_colorspace(cs, pdf)
-                yield dic
+            yield from page


### PR DESCRIPTION
Through the magic of `weakref.WeakValueDictionary` we can avoid dangling backreferences to the parent document for indirect objects parsed in worker processes.

This means that there is no longer any slowdown for small documents with multiple CPUs.