### PR TITLE
Make tables 60-100x faster with PLAYA-PDF 0.7.0 and its good page.structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,27 @@ structure tree, to look at the bounding boxes of the contents of those
 structure elements for a given page:
 
 ```python
-pi.box(pdf.structure.find_all(lambda el: el.page is page))
+pi.box(page.structure)
 ```
 
 ![Structure Elements](./docs/page3-elements.png)
 
-You can also look at the marked content sections, which are the
-leaf-nodes of the structure tree:
+Note however that this only gives you the elements associated with
+*marked content sections*, which are the leaf nodes of the structure
+tree.  So, you can also search up the structure tree to find things
+like tables, figures, or list items:
 
 ```python
-pi.box(page.structure)
+pi.box(page.structure.find_all("Table"))
+pi.box(page.structure.find_all("Figure"))
+pi.box(page.structure.find_all("LI"))
+```
+
+You can even search with regular expressions, to find headers for
+instance:
+
+```python
+pi.box(page.structure.find_all(re.compile(r"H\d+")))
 ```
 
 Alternately, if you have annotations (such as links), you can look at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "playa-pdf @ git+https://github.com/dhdaines/playa.git",
+    "playa-pdf>=0.7.0",
     "pillow",
 ]
 

--- a/src/paves/tables.py
+++ b/src/paves/tables.py
@@ -159,33 +159,23 @@ def table_elements_path(pdf: Union[str, PathLike]) -> Iterator[Element]:
 def table_elements_doc(pdf: Document) -> Iterator[Element]:
     structure = pdf.structure
     if structure is None:
-        raise TypeError
+        raise TypeError("Document has no logical structure")
     return structure.find_all("Table")
 
 
 @table_elements.register
 def table_elements_pagelist(pages: PageList) -> Iterator[Element]:
+    if pages.doc.structure is None:
+        raise TypeError("Document has no logical structure")
     for page in pages:
         yield from table_elements_page(page)
 
 
 @table_elements.register
 def table_elements_page(page: Page) -> Iterator[Element]:
-    structure = page.doc.structure
-    if structure is None:
-        raise TypeError
-    seen = set()
-    for element in page.structure:
-        while element is not None:
-            if element.role == "Table":
-                if element not in seen:
-                    yield element
-                seen.add(element)
-                break
-            # This isn't necessary but it makes mypy happy
-            if isinstance(element.parent, Tree):
-                break
-            element = element.parent
+    if page.structure is None:
+        raise TypeError("Page has no ParentTree")
+    return page.structure.find_all("Table")
 
 
 def table_elements_to_objects(

--- a/src/paves/tables.py
+++ b/src/paves/tables.py
@@ -178,9 +178,9 @@ def table_elements_page(page: Page) -> Iterator[Element]:
     for element in page.structure:
         while element is not None:
             if element.role == "Table":
-                if repr(element) not in seen:
+                if element not in seen:
                     yield element
-                seen.add(repr(element))
+                seen.add(element)
                 break
             # This isn't necessary but it makes mypy happy
             if isinstance(element.parent, Tree):


### PR DESCRIPTION
At long last, we can quickly get elements from the page structure!